### PR TITLE
optional parameter for input tensors in DQN and PPO

### DIFF
--- a/python/ray/rllib/agents/dqn/dqn_policy_graph.py
+++ b/python/ray/rllib/agents/dqn/dqn_policy_graph.py
@@ -363,7 +363,6 @@ class DQNPolicyGraph(LearningRateSchedule, DQNPostprocessing, TFPolicyGraph):
         )
         # Assert external input parameter (if any) matches expectations.
         assert isinstance(self.cur_observations, tf.Tensor) or isinstance(self.cur_observations, tf.Variable)
-        assert len(self.cur_observations.shape) == 2
 
         # Action Q network
         with tf.variable_scope(Q_SCOPE) as scope:

--- a/python/ray/rllib/agents/dqn/dqn_policy_graph.py
+++ b/python/ray/rllib/agents/dqn/dqn_policy_graph.py
@@ -364,7 +364,7 @@ class DQNPolicyGraph(LearningRateSchedule, DQNPostprocessing, TFPolicyGraph):
         # Assert external input parameter (if any) matches expectations.
         assert isinstance(self.cur_observations, tf.Tensor) or isinstance(self.cur_observations, tf.Variable)
         assert len(self.cur_observations.shape) == 2
-        assert self.cur_bservations.shape[1] == observation_space.shape
+        assert self.cur_observations.shape[1] == observation_space.shape[0]
 
         # Action Q network
         with tf.variable_scope(Q_SCOPE) as scope:

--- a/python/ray/rllib/agents/dqn/dqn_policy_graph.py
+++ b/python/ray/rllib/agents/dqn/dqn_policy_graph.py
@@ -355,7 +355,7 @@ class DQNPolicyGraph(LearningRateSchedule, DQNPostprocessing, TFPolicyGraph):
         self.stochastic = tf.placeholder(tf.bool, (), name="stochastic")
         self.eps = tf.placeholder(tf.float32, (), name="eps")
 
-        # Bonsai mod: allow to grow policy on top of prior transformations via a tensor passed in via
+        # Allow to grow policy on top of prior transformations via a tensor passed in via
         # an implicit parameter.
         self.cur_observations: Union[tf.Tensor, tf.Variable] = kw_args.get(
             "observations",

--- a/python/ray/rllib/agents/dqn/dqn_policy_graph.py
+++ b/python/ray/rllib/agents/dqn/dqn_policy_graph.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from typing import Any, Union
+
 from gym.spaces import Discrete
 import numpy as np
 from scipy.stats import entropy
@@ -338,7 +340,7 @@ class QValuePolicy(object):
 
 
 class DQNPolicyGraph(LearningRateSchedule, DQNPostprocessing, TFPolicyGraph):
-    def __init__(self, observation_space, action_space, config):
+    def __init__(self, observation_space, action_space, config, **kw_args: Any):
         config = dict(ray.rllib.agents.dqn.dqn.DEFAULT_CONFIG, **config)
         if not isinstance(action_space, Discrete):
             raise UnsupportedSpaceException(
@@ -352,8 +354,17 @@ class DQNPolicyGraph(LearningRateSchedule, DQNPostprocessing, TFPolicyGraph):
         # Action inputs
         self.stochastic = tf.placeholder(tf.bool, (), name="stochastic")
         self.eps = tf.placeholder(tf.float32, (), name="eps")
-        self.cur_observations = tf.placeholder(
-            tf.float32, shape=(None, ) + observation_space.shape)
+
+        # Bonsai mod: allow to grow policy on top of prior transformations via a tensor passed in via
+        # an implicit parameter.
+        self.cur_observations: Union[tf.Tensor, tf.Variable] = kw_args.get(
+            "observations",
+            tf.placeholder( tf.float32, shape=(None, ) + observation_space.shape)
+        )
+        # Assert external input parameter (if any) matches expectations.
+        assert isinstance(self.cur_observations, tf.Tensor) or isinstance(self.cur_observations, tf.Variable)
+        assert len(self.cur_observations.shape) == 2
+        assert self.cur_bservations.shape[1] == observation_space.shape
 
         # Action Q network
         with tf.variable_scope(Q_SCOPE) as scope:

--- a/python/ray/rllib/agents/dqn/dqn_policy_graph.py
+++ b/python/ray/rllib/agents/dqn/dqn_policy_graph.py
@@ -364,7 +364,6 @@ class DQNPolicyGraph(LearningRateSchedule, DQNPostprocessing, TFPolicyGraph):
         # Assert external input parameter (if any) matches expectations.
         assert isinstance(self.cur_observations, tf.Tensor) or isinstance(self.cur_observations, tf.Variable)
         assert len(self.cur_observations.shape) == 2
-        assert self.cur_observations.shape[1] == observation_space.shape[0]
 
         # Action Q network
         with tf.variable_scope(Q_SCOPE) as scope:

--- a/python/ray/rllib/agents/ppo/ppo_policy_graph.py
+++ b/python/ray/rllib/agents/ppo/ppo_policy_graph.py
@@ -146,7 +146,9 @@ class PPOPolicyGraph(LearningRateSchedule, PPOPostprocessing, TFPolicyGraph):
                  observation_space,
                  action_space,
                  config,
-                 existing_inputs=None):
+                 existing_inputs=None,
+                 **kwargs,
+                 ):
         """
         Arguments:
             observation_space: Environment observation space specification.
@@ -171,10 +173,14 @@ class PPOPolicyGraph(LearningRateSchedule, PPOPostprocessing, TFPolicyGraph):
             existing_state_in = existing_inputs[8:-1]
             existing_seq_lens = existing_inputs[-1]
         else:
-            obs_ph = tf.placeholder(
-                tf.float32,
-                name="obs",
-                shape=(None, ) + observation_space.shape)
+            obs_ph = kw_args.get(
+                "observations",
+                tf.placeholder(
+                    tf.float32,
+                    shape=(None, ) + observation_space.shape,
+                    name="obs",
+                )
+            )
             adv_ph = tf.placeholder(
                 tf.float32, name="advantages", shape=(None, ))
             act_ph = ModelCatalog.get_action_placeholder(action_space)

--- a/python/ray/rllib/agents/ppo/ppo_policy_graph.py
+++ b/python/ray/rllib/agents/ppo/ppo_policy_graph.py
@@ -147,7 +147,7 @@ class PPOPolicyGraph(LearningRateSchedule, PPOPostprocessing, TFPolicyGraph):
                  action_space,
                  config,
                  existing_inputs=None,
-                 **kwargs,
+                 **kw_args,
                  ):
         """
         Arguments:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Enable graph pipelining with external TF transformation. 
Right now, RLLIB Is locked to use a placeholder as an input which is created in policy constructors. 

this PR adds optional named parameters to policy constructors of DQN and PPO: 

* observations -- if passed, it is assumed to contain 2D tensor which will be used for policy observations. If not passed, the default construction mechanism for observation tensor is used (whichever defined in a specific policy class). Usually just a creation of shape (?,) + observation_space.shape. 

This does enabled pipelined graph construction outside RLLIB; however, rllib observations, at least during training, are still fed into the graph via python feed_dict into observation injection node; so any prior processing has to happen outside of rllib in a separate session run. However, it is possible to use the entire graph in a single session run for scenarios such as inference, where rllib is not involved directly into the inference.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
