### PR TITLE
Passing information about test/train to envs through action dict.

### DIFF
--- a/python/ray/rllib/evaluation/sampler.py
+++ b/python/ray/rllib/evaluation/sampler.py
@@ -34,6 +34,11 @@ PolicyEvalData = namedtuple("PolicyEvalData", [
     "prev_reward"
 ])
 
+# Bonsai Constants
+ACTION_TAG = 'act_tag'
+TEST_PROCESSED_ACTIONS = "test_processed_actions"
+IS_TEST = 'is_test'
+
 
 class PerfStats(object):
     """Sampler perf stats that will be included in rollout metrics."""
@@ -592,7 +597,13 @@ def _process_policy_eval_results(to_eval, eval_results, active_episodes,
                     action, policy.action_space)
             else:
                 actions_to_send[env_id][agent_id] = action
+
             episode = active_episodes[env_id]
+
+            # Bonsai modification so envs know if they are testing or training.
+            is_test: bool = True if episode.user_data.get(ACTION_TAG) == TEST_PROCESSED_ACTIONS else False
+            actions_to_send[env_id][IS_TEST] = is_test
+
             episode._set_rnn_state(agent_id, [c[i] for c in rnn_out_cols])
             episode._set_last_pi_info(
                 agent_id, {k: v[i]

--- a/python/ray/rllib/evaluation/sampler.py
+++ b/python/ray/rllib/evaluation/sampler.py
@@ -34,11 +34,6 @@ PolicyEvalData = namedtuple("PolicyEvalData", [
     "prev_reward"
 ])
 
-# Bonsai Constants
-ACTION_TAG = 'act_tag'
-TEST_PROCESSED_ACTIONS = "test_processed_actions"
-IS_TEST = 'is_test'
-
 
 class PerfStats(object):
     """Sampler perf stats that will be included in rollout metrics."""
@@ -559,6 +554,20 @@ def _do_policy_eval(tf_sess, to_eval, policies, active_episodes):
     return eval_results
 
 
+class ActionsToSendDict(defaultdict):
+    """Simple Dict like data structure that holds a nested dict of 
+    env id -> agent id -> agent replies, and also allows to carry
+    over the user data associated to the episodes.
+
+    Attributes:
+        user_data (dict): Dict that contains episode user data per
+        each env - env id -> user data 
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.user_data = defaultdict(dict)
+
+
 def _process_policy_eval_results(to_eval, eval_results, active_episodes,
                                  active_envs, off_policy_actions, policies,
                                  clip_actions):
@@ -571,9 +580,10 @@ def _process_policy_eval_results(to_eval, eval_results, active_episodes,
         actions_to_send: nested dict of env id -> agent id -> agent replies.
     """
 
-    actions_to_send = defaultdict(dict)
+    actions_to_send = ActionsToSendDict(dict)
     for env_id in active_envs:
         actions_to_send[env_id] = {}  # at minimum send empty dict
+        actions_to_send.user_data[env_id] = {} # with an empty dict of user data
 
     for policy_id, eval_data in to_eval.items():
         rnn_in_cols = _to_column_format([t.rnn_state for t in eval_data])
@@ -597,12 +607,9 @@ def _process_policy_eval_results(to_eval, eval_results, active_episodes,
                     action, policy.action_space)
             else:
                 actions_to_send[env_id][agent_id] = action
-
             episode = active_episodes[env_id]
 
-            # Bonsai modification so envs know if they are testing or training.
-            is_test: bool = True if episode.user_data.get(ACTION_TAG) == TEST_PROCESSED_ACTIONS else False
-            actions_to_send[env_id][IS_TEST] = is_test
+            actions_to_send.user_data[env_id][agent_id] = episode.user_data.copy()
 
             episode._set_rnn_state(agent_id, [c[i] for c in rnn_out_cols])
             episode._set_last_pi_info(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Envs cannot currently find out if they are running a test episode or train episode, because those were not concepts that existed in RLLib. 

Here we are proposing to allow the actions dict carry user data defined for the episodes.

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
Might close 14885

## Checks

- [x ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x ] Unit tests
   - [ x] Release tests
   - [ ] This PR is not tested (please justify below)
