### PR TITLE
Making tests run with the right Pytorch version

### DIFF
--- a/docker/examples/Dockerfile
+++ b/docker/examples/Dockerfile
@@ -13,4 +13,4 @@ RUN pip install --upgrade hyperopt==0.1.2
 RUN pip install --upgrade sigopt
 # RUN pip install --upgrade nevergrad
 RUN pip install --upgrade scikit-optimize
-RUN conda install -y pytorch-cpu torchvision-cpu -c pytorch
+RUN conda install -y pytorch-cpu=1.0.1 torchvision-cpu=0.2.2 -c pytorch

--- a/docker/tune_test/Dockerfile
+++ b/docker/tune_test/Dockerfile
@@ -13,7 +13,7 @@ RUN pip install --upgrade git+git://github.com/hyperopt/hyperopt.git
 RUN pip install --upgrade sigopt
 # RUN pip install --upgrade nevergrad
 RUN pip install --upgrade scikit-optimize
-RUN conda install pytorch-cpu torchvision-cpu -c pytorch
+RUN conda install pytorch-cpu=1.0.1 torchvision-cpu=0.2.2 -c pytorch
 
 # RUN mkdir -p /root/.ssh/
 


### PR DESCRIPTION
## Why are these changes needed?

Tests are being flaky with new versions of PyTorch.
In this PR we are setting the right version of PyTorch that should be used for Ray/RLlib 0.6.6

## Related issue number

None

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
