### PR TITLE
Adding the correct summary for flexible types

### DIFF
--- a/python/ray/rllib/utils/debug.py
+++ b/python/ray/rllib/utils/debug.py
@@ -78,15 +78,21 @@ def _summarize(obj):
     elif isinstance(obj, tuple):
         return tuple(_summarize(x) for x in obj)
     elif isinstance(obj, np.ndarray):
-        if obj.dtype == np.object:
+        if obj.size == 0:
+            return _StringValue("np.ndarray({}, dtype={})".format(
+                obj.shape, obj.dtype))
+        elif obj.dtype == np.object:
             return _StringValue("np.ndarray({}, dtype={}, head={})".format(
                 obj.shape, obj.dtype, _summarize(obj[0])))
-        else:
+        elif not issubclass(obj.dtype.type, np.flexible):
             return _StringValue(
                 "np.ndarray({}, dtype={}, min={}, max={}, mean={})".format(
                     obj.shape, obj.dtype, round(float(np.min(obj)), 3),
                     round(float(np.max(obj)), 3), round(
                         float(np.mean(obj)), 3)))
+        else:
+            return _StringValue("np.ndarray({}, dtype={}, head={})".format(
+                obj.shape, obj.dtype, obj))
     elif isinstance(obj, MultiAgentBatch):
         return {
             "type": "MultiAgentBatch",


### PR DESCRIPTION
## Why are these changes needed?

The debug summary is not considering the presence of flexible types on the observations.

## Related issue number

None

## Checks

- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested (please justify below)
