### PR TITLE
Features

### DIFF
--- a/deploy/ray-operator/README.md
+++ b/deploy/ray-operator/README.md
@@ -96,6 +96,8 @@ The instructions assume you have access to a running Kubernetes cluster via ``ku
 
 ### Running the unit tests
 
+make sure kubebuilder is installed. follow the instructions [here](https://book.kubebuilder.io/quick-start.html#installation).
+
 ```
 go build
 go test ./...
@@ -192,3 +194,5 @@ raycluster-sample-head   ClusterIP   10.100.153.12   <none>        6379/TCP   28
 # Delete the cluster.
 kubectl delete raycluster raycluster-sample
 ```
+# Flag usage:
+`--maximize-shared-memory=false/true`: when set to true, it will set the shared memory size to the requested (or limits if requests is missing) memory for the container.

--- a/deploy/ray-operator/controllers/raycluster_controller.go
+++ b/deploy/ray-operator/controllers/raycluster_controller.go
@@ -12,6 +12,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	"github.com/go-logr/logr"
 	_ "k8s.io/api/apps/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -43,8 +44,9 @@ var _ reconcile.Reconciler = &RayClusterReconciler{}
 // RayClusterReconciler reconciles a RayCluster object
 type RayClusterReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log               logr.Logger
+	Scheme            *runtime.Scheme
+	MaximizeSharedMem bool
 }
 
 // Reconcile reads that state of the cluster for a RayCluster object and makes changes based on it
@@ -191,6 +193,10 @@ func (r *RayClusterReconciler) buildPods(instance *rayiov1alpha1.RayCluster) []c
 	var pods []corev1.Pod
 	if instance.Spec.Extensions != nil && len(instance.Spec.Extensions) > 0 {
 		for _, extension := range instance.Spec.Extensions {
+			//maximize the shared memory
+			if r.MaximizeSharedMem {
+				addEmptyDir(&extension)
+			}
 			var i int32 = 0
 			for i = 0; i < *extension.Replicas; i++ {
 				podType := fmt.Sprintf("%v", extension.Type)
@@ -210,6 +216,48 @@ func (r *RayClusterReconciler) buildPods(instance *rayiov1alpha1.RayCluster) []c
 	}
 
 	return pods
+}
+
+func addEmptyDir(ext *rayiov1alpha1.Extension) {
+	//1) check if a mount exists on "/dev/shm"
+	for _, mount := range ext.VolumeMounts {
+		if mount.MountPath == "/dev/shm" {
+			log.Info("shared memory directory already mounted /dev/shm")
+			return
+		}
+	}
+	//2) create a Volume of type emptyDir and add it to Volumes
+	emptyDirVolume := corev1.Volume{
+		Name: "shared-mem",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				Medium:    corev1.StorageMediumMemory,
+				SizeLimit: findMemoryReqOrLimit(*ext),
+			},
+		},
+	}
+	ext.Volumes = append(ext.Volumes, emptyDirVolume)
+
+	//3) create a VolumeMount that uses the emptyDir
+	mountedVolume := corev1.VolumeMount{
+		MountPath: "/dev/shm",
+		Name:      "shared-mem",
+		ReadOnly:  false,
+	}
+	ext.VolumeMounts = append(ext.VolumeMounts, mountedVolume)
+
+}
+func findMemoryReqOrLimit(ext rayiov1alpha1.Extension) (res *resource.Quantity) {
+	mem := &resource.Quantity{}
+	//check the requests, if they are not set, check the limits.
+	if q, ok := ext.Resources.Requests[corev1.ResourceMemory]; ok {
+		mem = &q
+	} else {
+		if q, ok := ext.Resources.Limits[corev1.ResourceMemory]; ok {
+			mem = &q
+		}
+	}
+	return mem
 }
 
 // SetupWithManager builds the reconciler.

--- a/deploy/ray-operator/main.go
+++ b/deploy/ray-operator/main.go
@@ -29,10 +29,13 @@ func init() {
 
 func main() {
 	var metricsAddr string
-	var enableLeaderElection bool
+	var enableLeaderElection, maximizeSharedMem bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&maximizeSharedMem, "maximize-shared-memory", true,
+		"sets the /dev/shm size to the container resource requests or limits")
+
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(func(o *zap.Options) {
@@ -51,9 +54,10 @@ func main() {
 	}
 
 	if err = (&controllers.RayClusterReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("RayCluster"),
-		Scheme: mgr.GetScheme(),
+		Client:            mgr.GetClient(),
+		Log:               ctrl.Log.WithName("controllers").WithName("RayCluster"),
+		Scheme:            mgr.GetScheme(),
+		MaximizeSharedMem: maximizeSharedMem,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RayCluster")
 		os.Exit(1)


### PR DESCRIPTION
Unlike Docker, currently k8s does allow specifying the shared memory in a container. As a result, the Ray containers start with a warning message:
```WARNING: The object store is using /tmp instead of /dev/shm because /dev/shm has only 67108864 bytes available. This may slow down performance! You may be able to free up space by deleting files in /dev/shm or terminating any running plasma_store_server processes. If you are inside a Docker container, you may need to pass an argument with the flag '--shm-size' to 'docker run'.```

This PR fixed this issue. It adds a `--maximize-shared-memory=false/true` that when set to true, it will set the shared memory size to the requested (or limits if requests is missing) memory for the container.

Also, changed the readme file to explain the above flag.


## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested (please justify below)
