### PR TITLE
Adding runtime error related apis, metric aggregation, early bailout …

### DIFF
--- a/rllib/policy/tf_policy.py
+++ b/rllib/policy/tf_policy.py
@@ -1,5 +1,7 @@
 import errno
 import logging
+from typing import Dict, List, Any
+
 import numpy as np
 import os
 
@@ -474,6 +476,20 @@ class TFPolicy(Policy):
     def extra_compute_grad_fetches(self):
         """Extra values to fetch and return from compute_gradients()."""
         return {LEARNER_STATS_KEY: {}}  # e.g, stats, td error, etc.
+
+    @DeveloperAPI
+    def aggregate_dict_metric(self, name: str, dict_list: List[dict]) -> Any:
+        """ Aggregate dictonary metrics created by extra grad fetches. By default return the first
+        element only."""
+        return dict_list[0]
+
+    @DeveloperAPI
+    def check_sgd_iter_errors(self, minibatch_fetches: Any) -> bool:
+        """
+        Check (and possibly log) sgd iteration errors based on evaluated metrics.
+        :return: True if there are errors that must break optimization loop.
+        """
+        return False
 
     @DeveloperAPI
     def optimizer(self):

--- a/rllib/utils/sgd.py
+++ b/rllib/utils/sgd.py
@@ -1,4 +1,5 @@
 """Utils for minibatch SGD across multiple RLlib policies."""
+from typing import Optional, Callable, List, Any
 
 import numpy as np
 import logging
@@ -13,13 +14,14 @@ from ray.rllib.policy.sample_batch import SampleBatch, DEFAULT_POLICY_ID, \
 logger = logging.getLogger(__name__)
 
 
-def averaged(kv, axis=None):
+def averaged(kv, axis=None, dict_averaging_func: Optional[Callable[[str, List[dict]], Any]] = None):
     """Average the value lists of a dictionary.
 
     For non-scalar values, we simply pick the first value.
 
     Arguments:
         kv (dict): dictionary with values that are lists of floats.
+        dict_averaging_func: optional function averaging non-numeric (dictionary) arguments
 
     Returns:
         dictionary with single averaged float as values.
@@ -29,7 +31,10 @@ def averaged(kv, axis=None):
         if v[0] is not None and not isinstance(v[0], dict):
             out[k] = np.mean(v, axis=axis)
         else:
-            out[k] = v[0]
+            if dict_averaging_func is not None:
+                out[k] = dict_averaging_func(k, v)
+            else:
+                out[k] = v[0]
     return out
 
 


### PR DESCRIPTION


<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->
Right now, at least TFGPU Multi (used in PPO) takes non-numeric metrics corresponding to first minibatch of an SGD step/last SGD step, the information for all other steps (or even minibatches in the last SGD step) is lost. 

We want to be able to analyze and report runtime errors in any minibatch/sgd step. We also want to break SGD training early if we detected any fatal errors there. 

So we add two apis 
* to aggregate non-numeric metrics in ways other than just taking the one from last sgd iteration/first minibatch.
* to examine SGD evaluated fetches for runtime errors and break SGD training loop if we detect fatal errors (usually, loss errors that immediately would result to NaNs in weights of the policy, making further training impossible). 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
