### PR TITLE
Allow custom resources for ReplayBuffers

### DIFF
--- a/rllib/agents/sac/apex.py
+++ b/rllib/agents/sac/apex.py
@@ -36,7 +36,10 @@ APEX_SAC_DEFAULT_CONFIG = SACTrainer.merge_trainer_configs(
         # This only applies if async mode is used (above config setting).
         # Controls the max number of async requests in flight per actor
         "parallel_rollouts_num_async": 2,
+        "custom_resources_per_replay_buffer": {},
     },
+    _allow_unknown_configs=True,
+    _allow_unknown_subkeys=["custom_resources_per_replay_buffer"],
 )
 
 
@@ -48,4 +51,5 @@ ApexSACTrainer = SACTrainer.with_updates(
     name="APEX_SAC",
     default_config=APEX_SAC_DEFAULT_CONFIG,
     execution_plan=apex_execution_plan,
+    allow_unknown_subkeys=["custom_resources_per_replay_buffer"]
 )

--- a/rllib/agents/trainer.py
+++ b/rllib/agents/trainer.py
@@ -1174,7 +1174,8 @@ class Trainer(Trainable):
     def merge_trainer_configs(cls,
                               config1: TrainerConfigDict,
                               config2: PartialTrainerConfigDict,
-                              _allow_unknown_configs: Optional[bool] = None
+                              _allow_unknown_configs: Optional[bool] = None,
+                              _allow_unknown_subkeys: Optional[List[str]] = None,
                               ) -> TrainerConfigDict:
         config1 = copy.deepcopy(config1)
         if "callbacks" in config2 and type(config2["callbacks"]) is dict:
@@ -1188,8 +1189,10 @@ class Trainer(Trainable):
             config2["callbacks"] = make_callbacks
         if _allow_unknown_configs is None:
             _allow_unknown_configs = cls._allow_unknown_configs
+        if _allow_unknown_subkeys is None:
+            _allow_unknown_subkeys = []
         return deep_update(config1, config2, _allow_unknown_configs,
-                           cls._allow_unknown_subkeys,
+                           cls._allow_unknown_subkeys + _allow_unknown_subkeys,
                            cls._override_all_subkeys_if_type_changes)
 
     @staticmethod

--- a/rllib/agents/trainer_template.py
+++ b/rllib/agents/trainer_template.py
@@ -64,7 +64,8 @@ def build_trainer(
         mixins: Optional[List[type]] = None,
         execution_plan: Optional[Callable[[
             WorkerSet, TrainerConfigDict
-        ], Iterable[ResultDict]]] = default_execution_plan) -> Type[Trainer]:
+        ], Iterable[ResultDict]]] = default_execution_plan,
+        allow_unknown_subkeys: Optional[List[str]] =  None) -> Type[Trainer]:
     """Helper function for defining a custom trainer.
 
     Functions will be run in this order to initialize the trainer:
@@ -112,6 +113,8 @@ def build_trainer(
 
     original_kwargs = locals().copy()
     base = add_mixins(Trainer, mixins)
+    if allow_unknown_subkeys:
+        Trainer._allow_unknown_subkeys += allow_unknown_subkeys
 
     class trainer_cls(base):
         _name = name


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

@Edilmo @Kiko-Aumond @RuofanKong 

## Why are these changes needed?

We can now specify custom resources based placement for replay buffers for SAC and DQN.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(
